### PR TITLE
Update documentation - Generate multiple fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ helm upgrade --install secret-generator ./deploy/chart
 
 Add the annotation `secret-generator.v1.mittwald.de/autogenerate` to any Kubernetes
 secret object. The value of the annotation can be a field name 
-(or dot separated list of field names) within the secret; the
+(or comma separated list of field names) within the secret; the
 SecretGeneratorController will pick up this annotation and add a field [or fields] 
 (`password` in the example below) to the secret with a randomly generated string value.
 


### PR DESCRIPTION
If you want to generate multiple fields with this controller you have to use a comma as separator not a dot as noted before