### PR TITLE
add probes API

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -28,16 +28,19 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: {{ toYaml .Values.args | nindent 12 }}
+          ports:
+            - containerPort: 8080
+              name: healthcheck
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: healthcheck
             initialDelaySeconds: 3
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8080
+              port: healthcheck
             initialDelaySeconds: 3
             periodSeconds: 3
           env:
@@ -65,5 +68,5 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-    {{- toYaml . | nindent 8 }}
+  {{- toYaml . | nindent 8 }}
   {{- end }}

--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -28,6 +28,18 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: {{ toYaml .Values.args | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
           env:
             - name: WATCH_NAMESPACE
               value: {{ .Values.watchNamespace }}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,18 @@ spec:
           command:
             - kubernetes-secret-generator
           imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,16 +20,19 @@ spec:
           command:
             - kubernetes-secret-generator
           imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: healthcheck
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: healthcheck
             initialDelaySeconds: 3
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8080
+              port: healthcheck
             initialDelaySeconds: 3
             periodSeconds: 3
           env:


### PR DESCRIPTION
Adds Liveness and Readiness checks by making use of the
controller-runtime's healthz package.

These are just some simple probes which guarantee basic functionality.

fixes #12 