### PR TITLE
Deployment: use strategy.type = Recreate

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   {{- include "kubernetes-secret-generator.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
   {{- include "kubernetes-secret-generator.selectorLabels" . | nindent 6 }}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kubernetes-secret-generator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: kubernetes-secret-generator


### PR DESCRIPTION
Hi,

A `Recreate` strategy (compared to `RollingUpdate` default) is needed
because the newer pod will wait to be elected before becoming Ready and
the older pod will only be removed when the newer one is Ready, resulting in
a deadlock.

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>