### PR TITLE
health probes: increase initial delay 3→6

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -35,13 +35,13 @@ spec:
             httpGet:
               path: /healthz
               port: healthcheck
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /readyz
               port: healthcheck
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
             periodSeconds: 3
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -27,13 +27,13 @@ spec:
             httpGet:
               path: /healthz
               port: healthcheck
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /readyz
               port: healthcheck
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
             periodSeconds: 3
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Hi,

On some loaded clusters, the operator takes time to become ready. Thus
we increase the initial delay from 3s to 6s.

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>