### PR TITLE
Add priorityClassName field to kubernetes-secret-generator pod spec

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
     {{- include "kubernetes-secret-generator.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote}}
+      {{- end }}
       {{- include "kubernetes-secret-generator.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) | nindent 6 }}
       serviceAccountName: {{ include "kubernetes-secret-generator.serviceAccountName" . }}
       securityContext:

--- a/deploy/helm-chart/kubernetes-secret-generator/values.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/values.yaml
@@ -26,6 +26,8 @@ serviceAccount:
 podSecurityContext: {}
   # fsGroup: 2000
 
+priorityClassName: ""
+
 securityContext: {}
   # capabilities:
   #   drop:


### PR DESCRIPTION
An optional priorityClassName spec for KSG pods

Useful when we want to define priorities between various resources in the cluster with limited number of nodes