### PR TITLE
Fix helm ClusterRole for secret creation

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/clusterrole.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
       - secrets
     verbs:
       - get
+      - create
       - list
       - watch
       - update


### PR DESCRIPTION
Helm ClusterRole is not up to date with `deploy/role.yaml`.

With the CR feature, the create verb is necessary to create secrets.