### PR TITLE
Adds possibility to disable CRDs on the binary

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -68,6 +68,8 @@ func main() {
 	pflag.Int("ssh-key-length", 2048, "Default length of SSH Keys")
 	pflag.String("secret-encoding", "base64", "Encoding for secrets")
 	pflag.Bool("use-metrics-service", false, "Whether or not to use metrics service")
+	pflag.Bool("disable-crd-support", false, "Whether to disable CRD support and registering")
+
 	pflag.Parse()
 
 	// Import flags into viper and bind them to env vars
@@ -182,7 +184,7 @@ func main() {
 	}
 
 	// Setup all Controllers
-	if err = controller.AddToManager(mgr); err != nil {
+	if err = controller.AddToManager(mgr, !viper.GetBool("disable-crd-support")); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -29,7 +29,12 @@ spec:
           {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "kubernetes-secret-generator.images.image" (dict "root" . "Values" .Values.image)}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: {{ toYaml .Values.args | nindent 12 }}
+          args:
+            {{- $args := .Values.args }}
+            {{- if not .Values.installCRDs }}
+              {{- $args = append $args "--disable-crd-support" }}
+            {{- end }}
+            {{- toYaml $args | nindent 12 }}
           ports:
             - containerPort: 8080
               name: healthcheck

--- a/deploy/helm-chart/kubernetes-secret-generator/values.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/values.yaml
@@ -1,3 +1,4 @@
+installCRDs: true
 global:
   imageRegistry:
   imagePullSecrets:

--- a/pkg/controller/add_basicauth.go
+++ b/pkg/controller/add_basicauth.go
@@ -6,5 +6,5 @@ import (
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, basicauth.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, managerFunc{true, basicauth.Add})
 }

--- a/pkg/controller/add_secret.go
+++ b/pkg/controller/add_secret.go
@@ -6,5 +6,5 @@ import (
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, secret.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, managerFunc{false, secret.Add})
 }

--- a/pkg/controller/add_sshkeypair.go
+++ b/pkg/controller/add_sshkeypair.go
@@ -6,5 +6,5 @@ import (
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, sshkeypair.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, managerFunc{true, sshkeypair.Add})
 }

--- a/pkg/controller/add_stringsecret.go
+++ b/pkg/controller/add_stringsecret.go
@@ -6,5 +6,5 @@ import (
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, stringsecret.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, managerFunc{true, stringsecret.Add})
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -4,14 +4,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+type managerFunc struct {
+	isCRD       bool
+	managerFunc func(manager.Manager) error
+}
+
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []managerFunc
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
-	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
-			return err
+func AddToManager(m manager.Manager, enableCRDs bool) error {
+	for _, mf := range AddToManagerFuncs {
+		if enableCRDs || !mf.isCRD {
+			if err := mf.managerFunc(m); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
When not using CRDs, the binary currently crashes. This PR adds a flag to disable CRD support and make it possible to install the helm chart with the previous injection method.

Fixes #71 