### PR TITLE
Fixes #75

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/role.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/role.yaml
@@ -55,6 +55,21 @@ rules:
       - list
       - watch
       - update
+  # Permissions to access CRDs in this namespace if no cluster role is created.
+  - apiGroups:
+      - secretgenerator.mittwald.de
+    resources:
+      - basicauths
+      - basicauths/status
+      - sshkeypairs
+      - sshkeypairs/status
+      - stringsecrets
+      - stringsecrets/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
   {{- end -}}
 {{- else -}}
 kind: Role
@@ -96,6 +111,21 @@ rules:
     verbs:
       - get
       - create
+      - list
+      - watch
+      - update
+  # Permissions to access CRDs in this namespace if no cluster role is created.
+  - apiGroups:
+      - secretgenerator.mittwald.de
+    resources:
+      - basicauths
+      - basicauths/status
+      - sshkeypairs
+      - sshkeypairs/status
+      - stringsecrets
+      - stringsecrets/status
+    verbs:
+      - get
       - list
       - watch
       - update

--- a/deploy/helm-chart/kubernetes-secret-generator/templates/role.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/role.yaml
@@ -51,6 +51,7 @@ rules:
       - secrets
     verbs:
       - get
+      - create
       - list
       - watch
       - update
@@ -94,6 +95,7 @@ rules:
       - secrets
     verbs:
       - get
+      - create
       - list
       - watch
       - update


### PR DESCRIPTION
When cluster role is disabled, the Role should have permissions to watch for CRDs and create secrets like the ClusterRole.