### PR TITLE
Add pod annotations to Helm chart

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
     {{- include "kubernetes-secret-generator.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote}}

--- a/deploy/helm-chart/kubernetes-secret-generator/values.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/values.yaml
@@ -24,6 +24,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+podAnnotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
This PR adds an option to set pod annotations when using the Helm chart.