### PR TITLE
Add pod annotation support to Helm chart

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/_helpers.tpl
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/_helpers.tpl
@@ -109,3 +109,11 @@ imagePullSecrets:
         {{ .Values.repository }}:{{ .Values.tag | default .root.Chart.AppVersion }}
     {{- end }}
 {{- end -}}
+
+{{- define "kubernetes-secret-generator.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
     {{- include "kubernetes-secret-generator.selectorLabels" . | nindent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- include "kubernetes-secret-generator.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote}}

--- a/deploy/helm-chart/kubernetes-secret-generator/values.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/values.yaml
@@ -37,6 +37,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+podAnnotations: {}
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
Alternative to https://github.com/mittwald/kubernetes-secret-generator/pull/79, which allows using templating for the annotations.
Modelled from Bitnami charts: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_tplvalues.tpl