### PR TITLE
fix: pull secrets example in values

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/values.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/values.yaml
@@ -9,10 +9,10 @@ image:
   # if no tag is given, the chart's appVersion is used
   # tag: latest
   pullPolicy: Always
+  pullSecrets: []
 
 args: []
 
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 deploymentStrategy: "Recreate"


### PR DESCRIPTION
This PR fixes the values.yaml. In the values.yaml the key `.Values.imagePullSecrets` is included wich is misleading as it is not used.

The helper method uses the values in `.global.imagePullSecrets ` and `.Values.images.pullSecrets`. Hence I deleted the `imagePullSecrets` Key and moved it to `.Values.images.pullSecrets`.


__helperts.tpl_
...
```
{{- define "kubernetes-secret-generator.images.pullSecrets" -}}
  {{- $pullSecrets := list }}

  {{- if .global }}
    {{- range .global.imagePullSecrets -}}
      {{- $pullSecrets = append $pullSecrets . -}}
    {{- end -}}
  {{- end -}}

  {{- range .images -}}
    {{- range .pullSecrets -}}
      {{- $pullSecrets = append $pullSecrets . -}}
    {{- end -}}
  {{- end -}}

  {{- if (not (empty $pullSecrets)) }}
imagePullSecrets:
    {{- range $pullSecrets }}
  - name: {{ . }}
    {{- end }}
  {{- end }}
{{- end -}}
```
...