### PR TITLE
Add the option to opt out of service account token automounting

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
     {{- include "kubernetes-secret-generator.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote}}
       {{- end }}
@@ -67,6 +70,7 @@ spec:
               value: {{ .Values.useMetricsService | quote }}
           resources:
       {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts: {{ .Values.volumeMounts | toYaml | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -79,3 +83,4 @@ spec:
       tolerations:
   {{- toYaml . | nindent 8 }}
   {{- end }}
+      volumes: {{ .Values.volumes | toYaml | nindent 8 }}

--- a/deploy/helm-chart/kubernetes-secret-generator/templates/serviceaccount.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/serviceaccount.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+{{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ include "kubernetes-secret-generator.serviceAccountName" . }}
   labels:

--- a/deploy/helm-chart/kubernetes-secret-generator/values.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/values.yaml
@@ -17,7 +17,10 @@ nameOverride: ""
 fullnameOverride: ""
 deploymentStrategy: "Recreate"
 
+automountServiceAccountToken:
+
 serviceAccount:
+  automountServiceAccountToken:
   # Specifies whether a service account should be created
   create: true
   # The name of the service account to use.
@@ -65,6 +68,10 @@ secretLength: 40
 watchNamespace: ""
 
 useMetricsService: false
+
+volumeMounts: []
+
+volumes: []
 
 # RBAC parameteres
 # https://kubernetes.io/docs/reference/access-authn-authz/rbac/


### PR DESCRIPTION
* Allow the service account token automounting feature to be disabled on both the ServiceAccount itself and the Pod
* Allow for arbitrary volumes to be mounted in the Pod, so that the service account token can be manually injected into the Pod