### PR TITLE
Add customizable liveness and readiness probes

### DIFF
--- a/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/templates/deployment.yaml
@@ -41,18 +41,28 @@ spec:
           ports:
             - containerPort: 8080
               name: healthcheck
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: healthcheck
-            initialDelaySeconds: 6
-            periodSeconds: 3
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /readyz
               port: healthcheck
-            initialDelaySeconds: 6
-            periodSeconds: 3
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}              
           env:
             - name: WATCH_NAMESPACE
               value: {{ template "kubernetes-secret-generator.watchNamespace" . }}

--- a/deploy/helm-chart/kubernetes-secret-generator/values.yaml
+++ b/deploy/helm-chart/kubernetes-secret-generator/values.yaml
@@ -27,12 +27,14 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
 priorityClassName: ""
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -40,7 +42,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -83,3 +86,18 @@ rbac:
   # ClusterRole is deployed by Default
   clusterRole: true
 
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 6
+  periodSeconds: 3
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 6
+  periodSeconds: 3
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3


### PR DESCRIPTION
This PR introduces the ability to customize the liveness and readiness probes through the chart's values.yaml. Users can now adjust the initial delay, period, timeout, success threshold, and failure threshold for both probes. Additionally, it's now possible to disable either probe by setting the `enabled` flag to false.

This enhancement improves the flexibility of the deployment configurations, allowing users to tailor the health check mechanisms to better suit their specific service requirements and operational environments.

Changes made:
- Updated values.yaml to include default configurations for liveness and readiness probes. (Doesn't change the default behavior)
- Modified deployment.yaml to use the values from values.yaml for setting up the probes, including conditional checks to enable or disable them as configured.

This change resolves https://github.com/mittwald/kubernetes-secret-generator/issues/96, addressing the need for more configurable liveness and readiness probes as requested by the community.